### PR TITLE
Fix check_if_dataframe_sequence

### DIFF
--- a/mitoolspro/pandas_utils/utils.py
+++ b/mitoolspro/pandas_utils/utils.py
@@ -164,8 +164,6 @@ def check_if_dataframe_sequence(
             ]
         except (ValueError, TypeError, IndexError) as e:
             raise ArgumentValueError(f"Invalid sequence value in filenames: {e}")
-        sequence_files = sequence_dir.glob("*.parquet")
-        sequence_files = [int(file.stem.split("_")[-1]) for file in sequence_files]
         return set(sequence_values) == set(sequence_files)
     return False
 

--- a/tests/pandas_utils/test_utils.py
+++ b/tests/pandas_utils/test_utils.py
@@ -345,6 +345,17 @@ class TestCheckIfDataFrameSequence(TestCase):
         )
         self.assertFalse(result)
 
+    def test_sequence_with_string_ids(self):
+        string_data = {
+            "a": DataFrame({"A": [1, 2]}),
+            "b": DataFrame({"B": [3, 4]}),
+        }
+        store_dataframe_sequence(string_data, "string_sequence", self.test_dir)
+        result = check_if_dataframe_sequence(
+            self.test_dir, "string_sequence", sequence_values=["a", "b"]
+        )
+        self.assertTrue(result)
+
 
 class TestSelectIndex(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- simplify `check_if_dataframe_sequence`
- add regression test for string sequence IDs

## Testing
- `pytest tests/pandas_utils/test_utils.py::TestCheckIfDataFrameSequence::test_sequence_with_string_ids -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685efc5a7e88833291661f6560386392