### PR TITLE
fix: add full git history fetch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     
     - name: Install system dependencies
       run: |


### PR DESCRIPTION
Fixes the setuptools_scm version detection error in CI by ensuring full git history is available for version calculation from tags.