### PR TITLE
fix: improve version detection for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     
     - name: Install system dependencies
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "vcs"
-tag-pattern = "v{version}"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["mitoolspro"]
@@ -89,6 +91,8 @@ dev = [
     "pytest-cov>=6.2.1",
     "commitizen>=3.29.0",
     "pre-commit>=4.0.0",
+    "hatch-vcs>=0.5.0",
+    "setuptools-scm>=8.2.0",
 ]
 [project.scripts]
 mitoolspro = "mitoolspro.cli:main"


### PR DESCRIPTION
## Fixes

- Add `fetch-depth: 0` to release workflow for full git history access
- Improve hatch-vcs configuration for better version detection in CI
- Add setuptools-scm and hatch-vcs as dev dependencies

## Problem

The release workflow was failing with setuptools_scm version detection errors due to shallow git clone and suboptimal hatch-vcs configuration.

## Solution

1. **Full Git History**: Ensure `fetch-depth: 0` in release workflow checkout
2. **Optimized Config**: Simplify hatch-vcs configuration to use defaults  
3. **Dependencies**: Add required version detection tools to dev dependencies

This enables proper v1.0.0 release creation.