### PR TITLE
Fix: Use mitoolspro environment for PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,12 +65,14 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
+    environment: mitoolspro
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        ref: ${{ github.event.inputs.version || github.ref }}
     
     - name: Set up Python
       uses: actions/setup-python@v4


### PR DESCRIPTION
Adds environment specification to access UV_PUBLISH_TOKEN from mitoolspro environment