### PR TITLE
Fix: Configure hatch-vcs for v1.0.0 tag format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "vcs"
+tag-regex = "^v(?P<version>\\d+\\.\\d+\\.\\d+)$"
 
 [tool.hatch.metadata]
 allow-direct-references = true


### PR DESCRIPTION
Adds proper tag regex to detect version from v1.0.0 format tags