### PR TITLE
fix: Complete OIDC trusted publishing setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,4 @@ jobs:
     - name: Build and publish package
       run: |
         uv build
-        uv publish --trusted-publishing
-      env:
-        UV_PUBLISH_TOKEN: ""
+        uv publish --trusted-publishing always


### PR DESCRIPTION
- Fixes uv publish syntax for trusted publishing
- Uses --trusted-publishing always instead of requiring token
- Ready for secure PyPI publishing via OIDC